### PR TITLE
Add support for multiple Discord webhooks with per-webhook thresholds

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,64 @@
+name: Sync with upstream
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # every Monday 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/fsvreddit/modqueue-tools.git
+          git fetch upstream main
+
+      - name: Attempt clean merge
+        id: merge
+        run: |
+          if git merge upstream/main --no-edit; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            git merge --abort
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push clean merge to main
+        if: steps.merge.outputs.conflict == 'false'
+        run: git push origin main
+
+      - name: Open PR when merge conflicts
+        if: steps.merge.outputs.conflict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch="sync-upstream-conflict"
+          git checkout -B "$branch"
+          git merge upstream/main --no-edit || true
+          git add -A
+          git commit -m "Sync upstream/main - unresolved conflicts, needs manual review" || true
+          git push origin "$branch" --force
+
+          if ! gh pr view "$branch" --json state >/dev/null 2>&1; then
+            gh pr create \
+              --title "Upstream sync has conflicts - manual resolution needed" \
+              --body "The weekly upstream sync could not merge cleanly. This branch contains conflict markers - resolve them and merge manually." \
+              --base main \
+              --head "$branch"
+          fi

--- a/src/alerting.ts
+++ b/src/alerting.ts
@@ -13,6 +13,11 @@ interface QueuedPostCount {
     count: number;
 }
 
+interface WebhookThresholds {
+    threshold?: number;
+    ageHours?: number;
+}
+
 function getTopPosts (modQueue: (Post | Comment)[], threshold: number): QueuedPostCount[] {
     const postIdList = modQueue.map(item => item instanceof Comment ? item.postId : item.id);
     const countedPosts = countBy(postIdList);
@@ -34,77 +39,100 @@ export async function checkAlerting (modQueue: (Post | Comment)[], queueItemProp
         return;
     }
 
-    let shouldAlert = false;
-    const alertThreshold = settings[AppSetting.AlertThreshold] as number;
-    const alertAgeHours = settings[AppSetting.AlertAgeHours] as number;
-
-    if (alertThreshold && modQueue.length >= alertThreshold) {
-        console.log(`Alerting: Queue length of ${modQueue.length} is over threshold of ${alertThreshold}`);
-        shouldAlert = true;
-    } else {
-        console.log(`Alerting: Queue length ${modQueue.length} is under threshold.`);
-    }
+    const globalAlertThreshold = settings[AppSetting.AlertThreshold] as number;
+    const globalAlertAgeHours = settings[AppSetting.AlertAgeHours] as number;
+    const webhookConfig = settings[AppSetting.DiscordWebhookConfig] as string;
+    const thresholdsPerWebhook = parseWebhookConfig(webhookConfig, discordWebhookUrls, globalAlertThreshold, globalAlertAgeHours);
 
     let agedItems: QueuedItemProperties[] = [];
     let oldestItem: QueuedItemProperties | undefined;
-    if (alertAgeHours && queueItemProps.length > 0) {
-        agedItems = queueItemProps.filter(item => new Date(item.queueDate) < subHours(new Date(), alertAgeHours));
-        oldestItem = queueItemProps.sort((a, b) => a.queueDate - b.queueDate)[0];
-    }
 
-    if (agedItems.length > 0 && alertAgeHours) {
-        console.log(`Alerting: Found ${agedItems.length} items over ${alertAgeHours} old`);
-        shouldAlert = true;
+    const subredditName = context.subredditName ?? await context.reddit.getCurrentSubredditName();
+    const alertMessageIdKey = "AlertMessageIds";
+    const alertMessageIdsStr = await context.redis.get(alertMessageIdKey);
+    const alertMessageIds = alertMessageIdsStr ? JSON.parse(alertMessageIdsStr) as Record<string, string> : {};
+    const maxQueueLengthKey = "MaxQueueLengthObserved";
+    const previousMaxQueueLengthStr = await context.redis.get(maxQueueLengthKey);
+    const previousMaxQueueLength = previousMaxQueueLengthStr ? parseInt(previousMaxQueueLengthStr, 10) : 0;
+    const alertingPausedKey = "AlertingPaused";
+
+    // Check for aged items once
+    if (globalAlertAgeHours && queueItemProps.length > 0) {
+        agedItems = queueItemProps.filter(item => new Date(item.queueDate) < subHours(new Date(), globalAlertAgeHours));
+        oldestItem = queueItemProps.sort((a, b) => a.queueDate - b.queueDate)[0];
     }
 
     if (oldestItem) {
         console.log(`Alerting: Oldest item: ${formatDurationToNow(new Date(oldestItem.queueDate))}`);
     }
 
-    const subredditName = context.subredditName ?? await context.reddit.getCurrentSubredditName();
+    // Check if alerting is paused globally
+    if (await context.redis.exists(alertingPausedKey)) {
+        console.log("Alerting: Alerting is currently paused, skipping alert.");
+        return;
+    }
 
-    const alertMessageIdKey = "AlertMessageIds";
-    const alertMessageIdsStr = await context.redis.get(alertMessageIdKey);
-    const alertMessageIds = alertMessageIdsStr ? JSON.parse(alertMessageIdsStr) as Record<string, string> : {};
+    // Determine which webhooks should alert
+    const webhooksToAlert: string[] = [];
+    const webhooksToDeactivate: string[] = [];
 
-    const maxQueueLengthKey = "MaxQueueLengthObserved";
-    const previousMaxQueueLengthStr = await context.redis.get(maxQueueLengthKey);
-    const previousMaxQueueLength = previousMaxQueueLengthStr ? parseInt(previousMaxQueueLengthStr, 10) : 0;
+    for (const webhookUrl of discordWebhookUrls) {
+        const thresholds = thresholdsPerWebhook[webhookUrl];
+        const alertThreshold = thresholds.threshold ?? globalAlertThreshold;
+        const alertAgeHours = thresholds.ageHours ?? globalAlertAgeHours;
 
-    const alertingPausedKey = "AlertingPaused";
+        let shouldAlertForThisWebhook = false;
 
-    if (!shouldAlert) {
-        console.log("Alerting: Conditions not met for alerting.");
+        if (alertThreshold && modQueue.length >= alertThreshold) {
+            console.log(`Alerting: Queue length of ${modQueue.length} is over threshold of ${alertThreshold} for webhook ${webhookUrl}`);
+            shouldAlertForThisWebhook = true;
+        }
+
+        if (agedItems.length > 0 && alertAgeHours) {
+            console.log(`Alerting: Found ${agedItems.length} items over ${alertAgeHours} old for webhook ${webhookUrl}`);
+            shouldAlertForThisWebhook = true;
+        }
+
+        if (shouldAlertForThisWebhook) {
+            webhooksToAlert.push(webhookUrl);
+        } else {
+            webhooksToDeactivate.push(webhookUrl);
+        }
+    }
+
+    // Handle deactivation for webhooks that are under threshold
+    if (webhooksToDeactivate.length > 0) {
         const [underAlertAction] = settings[AppSetting.UnderThresholdAction] as UnderThresholdAction[] | undefined ?? [UnderThresholdAction.None];
         if (underAlertAction === UnderThresholdAction.DeleteMessage) {
             console.log("Alerting: Deleting alert messages as queue is under threshold.");
-            for (const webhookUrl of discordWebhookUrls) {
+            for (const webhookUrl of webhooksToDeactivate) {
                 const messageId = alertMessageIds[webhookUrl];
                 if (messageId) {
                     await deleteWebhookMessage(webhookUrl, messageId);
+                    delete alertMessageIds[webhookUrl];
                 }
             }
         } else if (underAlertAction === UnderThresholdAction.UpdateMessage) {
             console.log("Alerting: Updating alert messages as queue is under threshold.");
             const message = `✅ The [modqueue](<https://www.reddit.com/r/${subredditName}/about/modqueue>) on /r/${subredditName} is now under the alerting thresholds. There ${pluralize("are", modQueue.length)} currently ${modQueue.length} ${pluralize("item", modQueue.length)} in the queue, and the maximum queue length seen was ${previousMaxQueueLength}.`;
-            for (const webhookUrl of discordWebhookUrls) {
+            for (const webhookUrl of webhooksToDeactivate) {
                 const messageId = alertMessageIds[webhookUrl];
                 if (messageId) {
                     await updateWebhookMessage(webhookUrl, messageId, message);
                 }
             }
         }
-
-        await context.redis.del(alertMessageIdKey, maxQueueLengthKey);
-
-        // Pause alerting for 15 minutes to avoid repeated alerts
-        await context.redis.set(alertingPausedKey, "", { expiration: addMinutes(new Date(), 15) });
-
-        return;
     }
 
-    if (await context.redis.exists(alertingPausedKey)) {
-        console.log("Alerting: Alerting is currently paused, skipping alert.");
+    // If no webhooks should alert, pause alerting and return
+    if (webhooksToAlert.length === 0) {
+        console.log("Alerting: No webhooks meet alerting conditions.");
+        // Only delete/clear the redis keys if all webhooks are under threshold
+        if (webhooksToDeactivate.length === discordWebhookUrls.length) {
+            await context.redis.del(alertMessageIdKey, maxQueueLengthKey);
+            // Pause alerting for 15 minutes to avoid repeated alerts
+            await context.redis.set(alertingPausedKey, "", { expiration: addMinutes(new Date(), 15) });
+        }
         return;
     }
 
@@ -124,7 +152,7 @@ export async function checkAlerting (modQueue: (Post | Comment)[], queueItemProp
     message += `\n* There ${pluralize("is", modQueue.length)} currently ${modQueue.length} ${pluralize("item", modQueue.length)} in the queue\n`;
 
     if (agedItems.length > 0) {
-        message += `* ${agedItems.length} ${pluralize("item", agedItems.length)} ${pluralize("is", agedItems.length)} over ${alertAgeHours} ${pluralize("hour", alertAgeHours)} old.`;
+        message += `* ${agedItems.length} ${pluralize("item", agedItems.length)} ${pluralize("is", agedItems.length)} over ${globalAlertAgeHours} ${pluralize("hour", globalAlertAgeHours)} old.`;
         if (oldestItem?.itemId) {
             let target: Post | Comment;
             if (isLinkId(oldestItem.itemId)) {
@@ -142,7 +170,7 @@ export async function checkAlerting (modQueue: (Post | Comment)[], queueItemProp
     const alertThresholdForIndividualPosts = settings[AppSetting.AlertThresholdForIndividualPosts] as number | undefined;
 
     // Check to see if any posts represent a large proportion of the mod queue
-    if (alertThreshold && alertThresholdForIndividualPosts && modQueue.length >= alertThreshold) {
+    if (globalAlertThreshold && alertThresholdForIndividualPosts && modQueue.length >= globalAlertThreshold) {
         const topQueuePosts = getTopPosts(modQueue, alertThresholdForIndividualPosts);
         for (const item of topQueuePosts) {
             const post = await context.reddit.getPostById(item.postId);
@@ -152,7 +180,7 @@ export async function checkAlerting (modQueue: (Post | Comment)[], queueItemProp
 
     const hasExistingMessage = Object.keys(alertMessageIds).length > 0;
     if (hasExistingMessage) {
-        for (const webhookUrl of discordWebhookUrls) {
+        for (const webhookUrl of webhooksToAlert) {
             const messageId = alertMessageIds[webhookUrl];
             if (messageId) {
                 await updateWebhookMessage(webhookUrl, messageId, message);
@@ -165,7 +193,7 @@ export async function checkAlerting (modQueue: (Post | Comment)[], queueItemProp
         }
         console.log("Alerting: Updated existing alert messages.");
     } else {
-        for (const webhookUrl of discordWebhookUrls) {
+        for (const webhookUrl of webhooksToAlert) {
             const newMessageId = await sendMessageToWebhook(webhookUrl, message);
             if (newMessageId) {
                 alertMessageIds[webhookUrl] = newMessageId;
@@ -255,4 +283,58 @@ function getDiscordWebhookUrls (webhookSetting: string | undefined): string[] {
         .split(/\n+/)
         .map(url => url.trim())
         .filter(url => url.length > 0);
+}
+
+function parseWebhookConfig (
+    configSetting: string | undefined,
+    webhookUrls: string[],
+    defaultThreshold: number,
+    defaultAgeHours: number,
+): Record<string, WebhookThresholds> {
+    const result: Record<string, WebhookThresholds> = {};
+
+    // Initialize all webhooks with default thresholds
+    for (const url of webhookUrls) {
+        result[url] = {
+            threshold: defaultThreshold,
+            ageHours: defaultAgeHours,
+        };
+    }
+
+    if (!configSetting) {
+        return result;
+    }
+
+    const configs = configSetting
+        .trim()
+        .split(/\n+/)
+        .filter(c => c.trim());
+
+    for (const config of configs) {
+        const parts = config.trim().split("|");
+        const url = parts[0].trim();
+
+        if (!webhookUrls.includes(url)) {
+            console.log(`Alerting: Webhook URL in config not found in main list: ${url}`);
+            continue;
+        }
+
+        const thresholds: WebhookThresholds = {
+            threshold: defaultThreshold,
+            ageHours: defaultAgeHours,
+        };
+
+        for (let i = 1; i < parts.length; i++) {
+            const [key, value] = parts[i].split(":").map(s => s.trim());
+            if (key === "threshold") {
+                thresholds.threshold = parseInt(value, 10);
+            } else if (key === "ageHours") {
+                thresholds.ageHours = parseInt(value, 10);
+            }
+        }
+
+        result[url] = thresholds;
+    }
+
+    return result;
 }

--- a/src/alerting.ts
+++ b/src/alerting.ts
@@ -28,8 +28,8 @@ export async function checkAlerting (modQueue: (Post | Comment)[], queueItemProp
         return;
     }
 
-    const discordWebhookUrl = settings[AppSetting.DiscordWebhook] as string;
-    if (!discordWebhookUrl) {
+    const discordWebhookUrls = getDiscordWebhookUrls(settings[AppSetting.DiscordWebhook] as string);
+    if (discordWebhookUrls.length === 0) {
         console.log("Alerting: Webhook is not set up!");
         return;
     }
@@ -63,8 +63,9 @@ export async function checkAlerting (modQueue: (Post | Comment)[], queueItemProp
 
     const subredditName = context.subredditName ?? await context.reddit.getCurrentSubredditName();
 
-    const alertMessageIdKey = "AlertMessageId";
-    let alertMessageId = await context.redis.get(alertMessageIdKey);
+    const alertMessageIdKey = "AlertMessageIds";
+    const alertMessageIdsStr = await context.redis.get(alertMessageIdKey);
+    const alertMessageIds = alertMessageIdsStr ? JSON.parse(alertMessageIdsStr) as Record<string, string> : {};
 
     const maxQueueLengthKey = "MaxQueueLengthObserved";
     const previousMaxQueueLengthStr = await context.redis.get(maxQueueLengthKey);
@@ -75,13 +76,23 @@ export async function checkAlerting (modQueue: (Post | Comment)[], queueItemProp
     if (!shouldAlert) {
         console.log("Alerting: Conditions not met for alerting.");
         const [underAlertAction] = settings[AppSetting.UnderThresholdAction] as UnderThresholdAction[] | undefined ?? [UnderThresholdAction.None];
-        if (underAlertAction === UnderThresholdAction.DeleteMessage && alertMessageId) {
-            console.log("Alerting: Deleting alert message as queue is under threshold.");
-            await deleteWebhookMessage(discordWebhookUrl, alertMessageId);
-        } else if (underAlertAction === UnderThresholdAction.UpdateMessage && alertMessageId) {
-            console.log("Alerting: Updating alert message as queue is under threshold.");
+        if (underAlertAction === UnderThresholdAction.DeleteMessage) {
+            console.log("Alerting: Deleting alert messages as queue is under threshold.");
+            for (const webhookUrl of discordWebhookUrls) {
+                const messageId = alertMessageIds[webhookUrl];
+                if (messageId) {
+                    await deleteWebhookMessage(webhookUrl, messageId);
+                }
+            }
+        } else if (underAlertAction === UnderThresholdAction.UpdateMessage) {
+            console.log("Alerting: Updating alert messages as queue is under threshold.");
             const message = `✅ The [modqueue](<https://www.reddit.com/r/${subredditName}/about/modqueue>) on /r/${subredditName} is now under the alerting thresholds. There ${pluralize("are", modQueue.length)} currently ${modQueue.length} ${pluralize("item", modQueue.length)} in the queue, and the maximum queue length seen was ${previousMaxQueueLength}.`;
-            await updateWebhookMessage(discordWebhookUrl, alertMessageId, message);
+            for (const webhookUrl of discordWebhookUrls) {
+                const messageId = alertMessageIds[webhookUrl];
+                if (messageId) {
+                    await updateWebhookMessage(webhookUrl, messageId, message);
+                }
+            }
         }
 
         await context.redis.del(alertMessageIdKey, maxQueueLengthKey);
@@ -139,17 +150,33 @@ export async function checkAlerting (modQueue: (Post | Comment)[], queueItemProp
         }
     }
 
-    if (alertMessageId) {
-        await updateWebhookMessage(discordWebhookUrl, alertMessageId, message);
-        console.log("Alerting: Updated existing alert message.");
-        return;
+    const hasExistingMessage = Object.keys(alertMessageIds).length > 0;
+    if (hasExistingMessage) {
+        for (const webhookUrl of discordWebhookUrls) {
+            const messageId = alertMessageIds[webhookUrl];
+            if (messageId) {
+                await updateWebhookMessage(webhookUrl, messageId, message);
+            } else {
+                const newMessageId = await sendMessageToWebhook(webhookUrl, message);
+                if (newMessageId) {
+                    alertMessageIds[webhookUrl] = newMessageId;
+                }
+            }
+        }
+        console.log("Alerting: Updated existing alert messages.");
+    } else {
+        for (const webhookUrl of discordWebhookUrls) {
+            const newMessageId = await sendMessageToWebhook(webhookUrl, message);
+            if (newMessageId) {
+                alertMessageIds[webhookUrl] = newMessageId;
+            }
+        }
+        console.log("Alerting: Sent new alert messages.");
     }
 
-    alertMessageId = await sendMessageToWebhook(discordWebhookUrl, message);
-
     // Record that we're in an alerting period with an expiry of a day
-    if (alertMessageId) {
-        await context.redis.set(alertMessageIdKey, alertMessageId, { expiration: addDays(new Date(), 1) });
+    if (Object.keys(alertMessageIds).length > 0) {
+        await context.redis.set(alertMessageIdKey, JSON.stringify(alertMessageIds), { expiration: addDays(new Date(), 1) });
     }
 }
 
@@ -217,4 +244,15 @@ async function deleteWebhookMessage (webhookUrl: string, messageId: string): Pro
     } catch (error) {
         console.error("Error deleting message to webhook:", error);
     }
+}
+
+function getDiscordWebhookUrls (webhookSetting: string | undefined): string[] {
+    if (!webhookSetting) {
+        return [];
+    }
+    return webhookSetting
+        .trim()
+        .split(/\n+/)
+        .map(url => url.trim())
+        .filter(url => url.length > 0);
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -66,13 +66,18 @@ export const appSettings: SettingsFormField[] = [
             {
                 name: AppSetting.DiscordWebhook,
                 type: "string",
-                label: "Discord webhook URL",
-                helpText: "The URL of the Discord webhook to send alerts to. Get this from your Discord server's settings or channel settings.",
+                label: "Discord webhook URLs",
+                helpText: "One or more Discord webhook URLs to send alerts to. Enter multiple URLs separated by newlines. Get these from your Discord server's or channel settings.",
                 placeholder: "https://discord.com/api/webhooks/123456789012345678/abcdefg",
                 onValidate: ({ value }) => {
                     const webhookRegex = /^https:\/\/discord(?:app)?.com\/api\/webhooks\/\d+\//;
-                    if (value && !webhookRegex.test(value)) {
-                        return "Please enter a valid Discord webhook URL";
+                    if (value) {
+                        const urls = value.trim().split(/\n+/).filter(url => url.trim());
+                        for (const url of urls) {
+                            if (!webhookRegex.test(url.trim())) {
+                                return "Please enter valid Discord webhook URLs";
+                            }
+                        }
                     }
                 },
             },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ export enum AppSetting {
     AlertAgeHours = "alertAgeHours",
     AlertThresholdForIndividualPosts = "alertThresholdForIndividualPosts",
     DiscordWebhook = "discordWebhook",
+    DiscordWebhookConfig = "discordWebhookConfig",
     UnderThresholdAction = "underThresholdAction",
     RoleToPing = "roleToPing",
 }
@@ -76,6 +77,40 @@ export const appSettings: SettingsFormField[] = [
                         for (const url of urls) {
                             if (!webhookRegex.test(url.trim())) {
                                 return "Please enter valid Discord webhook URLs";
+                            }
+                        }
+                    }
+                },
+            },
+            {
+                name: AppSetting.DiscordWebhookConfig,
+                type: "string",
+                label: "Per-webhook thresholds (optional)",
+                helpText: "Set different thresholds for specific webhooks. Format: one per line as 'WEBHOOK_URL|threshold:NUMBER|ageHours:NUMBER'. Leave blank to use default thresholds for all webhooks.",
+                placeholder: "https://discord.com/api/webhooks/123456789012345678/abcdefg|threshold:20|ageHours:12",
+                onValidate: ({ value }) => {
+                    const webhookRegex = /^https:\/\/discord(?:app)?.com\/api\/webhooks\/\d+\//;
+                    if (value) {
+                        const configs = value.trim().split(/\n+/).filter(c => c.trim());
+                        for (const config of configs) {
+                            const parts = config.trim().split("|");
+                            const url = parts[0];
+                            if (!webhookRegex.test(url)) {
+                                return "Invalid webhook URL in configuration";
+                            }
+                            for (let i = 1; i < parts.length; i++) {
+                                const param = parts[i];
+                                if (!param.includes(":")) {
+                                    return "Invalid configuration format. Use: URL|threshold:NUMBER|ageHours:NUMBER";
+                                }
+                                const [key, val] = param.split(":");
+                                if (["threshold", "ageHours"].includes(key.trim())) {
+                                    if (isNaN(Number(val))) {
+                                        return `Invalid value for ${key}: must be a number`;
+                                    }
+                                } else {
+                                    return `Unknown parameter: ${key}`;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Changes
- Allow users to configure multiple Discord webhook URLs (separated by newlines) instead of just one
- Add ability to set different alert thresholds for each webhook
- Updated settings UI to clarify that multiple URLs are supported
- Modified alert message tracking to store message IDs per webhook
- Alerts are now sent to all configured webhooks based on their individual thresholds

## How it works

### Multiple Webhooks
Users can enter multiple Discord webhook URLs in the "Discord webhook URLs" setting, each on a new line:
https://discord.com/api/webhooks/123456789/abc
https://discord.com/api/webhooks/987654321/xyz

### Per-Webhook Thresholds
Users can optionally set different thresholds for specific webhooks in the "Per-webhook thresholds (optional)" setting. Format: one per line as `WEBHOOK_URL|threshold:NUMBER|ageHours:NUMBER`

Example:
[https://discord.com/api/webhooks/123456789/abc|threshold:20|ageHours:12](https://discord.com/api/webhooks/123456789/abc%7Cthreshold:20%7CageHours:12)
[https://discord.com/api/webhooks/987654321/xyz|threshold:50|ageHours:24](https://discord.com/api/webhooks/987654321/xyz%7Cthreshold:50%7CageHours:24)



If left blank, all webhooks use the default global thresholds.

## Use Cases
- Alert multiple Discord servers/channels about the same modqueue events
- Use stricter thresholds for critical channels and looser ones for notifications channels
- Have one webhook alert on small queue size and another only on very large queues

## Backwards Compatible
Existing setups with a single webhook continue to work exactly as before. The per-webhook thresholds feature is completely optional.